### PR TITLE
fix: use dotenv-safe + simplify config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+LND_IP=
+LND_PORT=
+MACAROON_BASE64=
+DISCORD_TOKEN=
+DB_CONNECTION_URL=postgres://user:pass@example.com:5432/dbname

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Install dependencies:
 npm i
 ```
 
-Modify database configuration in [`src/config/config.js`](./src/config/config.js), or set `NODE_ENV=production` and set the Postgres environment variables defined below.
+Modify database configuration in [`src/config/index.js`](./src/config/index.js), or set `NODE_ENV=production` and set the Postgres environment variables defined below.
 
 Create the database and run migrations:
 ```bash
@@ -32,10 +32,7 @@ npm start
 
 ### Environment variables
 #### Postgres
-* `DB_USERNAME`
-* `DB_PASSWORD`
-* `DB_DATABASE`
-* `DB_HOST`
+* `DB_CONNECTION_URL`: eg: `postgres://user:pass@example.com:5432/dbname`
 
 #### Lightning
 * `LND_IP`

--- a/package-lock.json
+++ b/package-lock.json
@@ -373,6 +373,14 @@
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
       "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
     },
+    "dotenv-safe": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv-safe/-/dotenv-safe-8.2.0.tgz",
+      "integrity": "sha512-uWwWWdUQkSs5a3mySDB22UtNwyEYi0JtEQu+vDzIqr9OjbDdC2Ip13PnSpi/fctqlYmzkxCeabiyCAOROuAIaA==",
+      "requires": {
+        "dotenv": "^8.2.0"
+      }
+    },
     "dottie": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/dottie/-/dottie-2.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "canvas": "^2.6.1",
     "chalk": "^4.0.0",
     "discord.js": "^12.1.1",
-    "dotenv": "^8.2.0",
+    "dotenv-safe": "^8.2.0",
     "pg": "^8.0.2",
     "pg-hstore": "^2.3.3",
     "qrcode": "^1.4.4",

--- a/src/app.js
+++ b/src/app.js
@@ -1,33 +1,9 @@
 const Discord = require('discord.js');
 const handler = require('./handler');
 const Worker = require('./worker');
-
-let envVars = [
-  'LND_IP',
-  'LND_PORT',
-  'MACAROON_BASE64',
-  'DISCORD_TOKEN',
-];
-
-const prodVars = [
-  'DB_HOST',
-  'DB_DATABASE',
-  'DB_USERNAME',
-  'DB_PASSWORD',
-];
-
-if (process.env.NODE_ENV === 'production') {
-  envVars = [...envVars, ...prodVars]
-}
+const config = require('./config');
 
 (async () => {
-  // Check environment variables properly set
-  const missingEnv = envVars.filter(e => !process.env[e]);
-  if (missingEnv.length > 0) {
-    console.error('Required environment variables missing:', missingEnv.join(', '));
-    process.exit(1);
-  }
-
   // Postgres
   require('./models');
 
@@ -45,5 +21,5 @@ if (process.env.NODE_ENV === 'production') {
 
   client.on('message', handler);
 
-  client.login(process.env.DISCORD_TOKEN);
+  client.login(config.discordToken);
 })();

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -4,16 +4,10 @@ const fs = require('fs');
 const path = require('path');
 const Sequelize = require('sequelize');
 const basename = path.basename(__filename);
-const env = process.env.NODE_ENV || 'development';
-const config = require(__dirname + '/../config/config.js')[env];
+const { dbConnectionUrl } = require(__dirname + '/../config')
 const db = {};
 
-let sequelize;
-if (config.use_env_variable) {
-  sequelize = new Sequelize(process.env[config.use_env_variable], config);
-} else {
-  sequelize = new Sequelize(config.database, config.username, config.password, config);
-}
+const sequelize = new Sequelize(dbConnectionUrl);
 
 fs
   .readdirSync(__dirname)


### PR DESCRIPTION
I know this is opinionated so it's ok if you don't want such changes.

- `dotenv-safe` instead of `dotenv` for environment variable validation. also `.env.example` make it easier to understand for everyone. They can just copy, edit and save to `.env`.

- I'm not sure about the need to separate db config for each enviroment. Won't a single connection url suffice ?